### PR TITLE
Make nerves-env.sh compatible with zsh and others

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -3,21 +3,38 @@
 # Source this script to setup your environment to cross-compile
 # and build Erlang apps for this Nerves build.
 
-if [ "$SHELL" != "/bin/bash" ]; then
-    echo ERROR: This script currently only works from bash.
-    exit 1
+# If the script is called with the -get-nerves-root flag it just returns the
+# Nerves SDK directory. This is so that other shells can execute the script
+# without needing to implement the equivalent of $BASH_SOURCE for every shell.
+for arg in $*
+do
+    if [ $arg = "-get-nerves-root" ];
+    then
+        echo $(dirname $(readlink -f $BASH_SOURCE))
+        exit 0
+    fi
+done 
+
+
+if [[ "$SHELL" = "/bin/bash" ]]; then
+    if [ "$0" != "bash" -a "$0" != "-bash" -a "$0" != "/bin/bash" ]; then
+        echo ERROR: This scripted should be sourced from bash:
+        echo
+        echo source $BASH_SOURCE
+        echo
+        return 1
+        exit 1
+    fi
+#elif [[ "$SHELL" = "/bin/zsh" ]]; then
 fi
 
-if [ "$0" != "bash" -a "$0" != "-bash" -a "$0" != "/bin/bash" ]; then
-    echo ERROR: This scripted should be sourced from bash:
-    echo
-    echo source $BASH_SOURCE
-    echo
-    return 1
-    exit 1
+if [ "$BASH_SOURCE" = "" ]; then
+    GET_NR_COMMAND="$0 $@ -get-nerves-root"
+    NERVES_ROOT=$(bash -c "$GET_NR_COMMAND")
+else
+    NERVES_ROOT=$(dirname $(readlink -f $BASH_SOURCE))
 fi
 
-NERVES_ROOT=$(dirname $(readlink -f $BASH_SOURCE))
 NERVES_DEFCONFIG=`grep BR2_DEFCONFIG= $NERVES_ROOT/buildroot/.config | sed -e 's/.*"\(.*\)"/\1/'`
 
 source $NERVES_ROOT/scripts/nerves-env-helper.sh $NERVES_ROOT
@@ -26,3 +43,4 @@ echo "Shell environment updated for Nerves"
 echo
 echo "Nerves configuration: $NERVES_DEFCONFIG"
 echo "Cross-compiler prefix: `basename $CROSSCOMPILE`"
+

--- a/scripts/nerves-env-helper.sh
+++ b/scripts/nerves-env-helper.sh
@@ -17,11 +17,11 @@ export NERVES_SDK_SYSROOT
 
 # Rebar environment variables
 PLATFORM_DIR=$NERVES_ROOT/sdk/$NERVES_PLATFORM
-
 ERTS_DIR=`ls -d $NERVES_SDK_SYSROOT/usr/lib/erlang/erts-*`
 ERL_INTERFACE_DIR=`ls -d $NERVES_SDK_SYSROOT/usr/lib/erlang/lib/erl_interface-*`
 ALL_CROSSCOMPILE=`ls $NERVES_SDK_ROOT/usr/bin/*gcc | sed -e s/-gcc//`
-if [ "$ALL_CROSSCOMPILE" == "" ]; then
+
+if [ "$ALL_CROSSCOMPILE" = "" ]; then
     echo ERROR: Nerves SDK must be built first
     echo
     echo "make <board_defconfig>"
@@ -32,6 +32,7 @@ fi
 # to the crosscompiler, so two entries show up. The logic below picks the first
 # crosscompiler by default or the one with buildroot in its name.
 CROSSCOMPILE=`echo $ALL_CROSSCOMPILE | head -n 1`
+
 for i in $ALL_CROSSCOMPILE; do
     case `basename $i` in
         *buildroot* )


### PR DESCRIPTION
Update nerves-env.sh to call itself under Bash if used in another shell
to get the correct file location.

Tested in Bash and zsh calling directly, through a symlink, an alias and
PATH.

Equalities also fixed where needed to be compatible with zsh since bash
aliases "==" to "=" and zsh does not.