### PR TITLE
Add dependencies needed on Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before building Nerves, it is important to have a few build tools
 already installed. Buildroot provides a lot, but it does depend on
 a few host programs. If using Ubuntu, run the following:
 
-    sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4
+    sudo apt-get install git g++ libssl-dev libncurses5-dev bc m4 make unzip
 
     # If your system is 64-bit, also run this
     sudo apt-get install libc6:i386 libstdc++6:i386 zlib1g:i386 gcc-multilib


### PR DESCRIPTION
When following these steps on Ubuntu 14.04 Server edition, I also needed these two packages to get through the build process.