### PR TITLE
Configure Travis-CI to upload artifacts to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ buildroot
 .buildroot-patched
 *~
 .nerves-defconfig
+/artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,21 @@ sudo: false
 addons:
     apt:
         packages:
-            - bc
-            - libssl-dev
+        - bc
+        - libssl-dev
+    artifacts:
+        paths:
+          - artifacts
 env:
     matrix:
-        - DEFCONFIG_NAME=nerves_bbb_defconfig
-        - DEFCONFIG_NAME=nerves_rpi_elixir_defconfig
-        - DEFCONFIG_NAME=nerves_rpi2_elixir_defconfig
+    - NERVES_CONFIG=bbb
+    - NERVES_CONFIG=rpi_elixir
+    - NERVES_CONFIG=rpi2_elixir
+
+script: bash scripts/ci.sh
 
 #branches:
 #    only:
 #        - master
 
 
-# Much of this was copied from the Buildroot .travis.yml. See
-# https://github.com/buildroot/buildroot-defconfig-testing/blob/master/.travis.yml
-script:
-    - export LD_LIBRARY_PATH=
-    - make --silent ${DEFCONFIG_NAME}
-    - while true ; do echo "Still building" ; sleep 60 ; done &
-    - stupidpid=$!
-    - make > >(tee build.log | grep '>>>') 2>&1
-    - kill ${stupidpid}
-    - echo 'Display end of log'
-    - tail -1000 build.log

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,22 @@
+# Much of this was copied from the Buildroot .travis.yml. See
+# https://github.com/buildroot/buildroot-defconfig-testing/blob/master/.travis.yml
+export DEFCONFIG_NAME="nerves_${NERVES_CONFIG}_defconfig"
+export LD_LIBRARY_PATH=
+
+# Configure platform
+make --silent $DEFCONFIG_NAME
+
+# Build the SDK
+while true ; do echo "Still building" ; sleep 60 ; done &
+stupidpid=$!
+make > >(tee build.log | grep '>>>') 2>&1
+kill ${stupidpid}
+echo 'Display end of log'
+tail -1000 build.log
+
+# Create artifacts
+make system
+rm -fr artifacts
+mkdir artifacts
+cp system.tar.gz artifacts
+cp buildroot/output/images/*.fw artifacts


### PR DESCRIPTION
**This works for me on my fork, but I don't have permission to edit the nerves-project settings on travis-ci to add the S3 keys.** See https://travis-ci.org/fatehitech/nerves-sdk/jobs/94814098#L118-L121 for what they need to look like. Credentials are in private message in slack.

Each `NERVES_CONFIG` in the travis.yml creates a build job.

There, `scripts/ci.sh` executes, setting `DEFCONFIG_NAME` and building everything, and finally preparing the artifact files.

Travis then uploads the artifacts to S3 for each build job.

E.g. Build 9.1 (NERVES_CONFIG=bbb) can be seen here https://travis-ci.org/fatehitech/nerves-sdk/jobs/94814098 and, upon success, had produced the following artifacts: 

* https://s3.amazonaws.com/nerves-project/fatehitech/nerves-sdk/9/9.1/nerves-bbb-base.fw
* https://s3.amazonaws.com/nerves-project/fatehitech/nerves-sdk/9/9.1/system.tar.gz